### PR TITLE
Reference "source_dir" over "cwd" in installation

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+if [ "$AZUL_DIR" == "" ]
+then
+    export AZUL_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+fi
+
 if [ "$AZUL_PREFIX" == "" ]
 then
     export AZUL_PREFIX=$HOME/.local
@@ -38,10 +43,10 @@ fi
 export AZUL_CONFIG="${XDG_CONFIG_HOME:-$HOME}/.config/azul"
 
 printf "#!/bin/bash\n\nexport AZUL_PREFIX=$AZUL_PREFIX\nexport AZUL_ABDUCO_EXE=$AZUL_ABDUCO_EXE\nexport AZUL_NVIM_EXE=$AZUL_NVIM_EXE\n\n" > $AZUL_PREFIX/bin/azul
-cat ./azul >> $AZUL_PREFIX/bin/azul
+cat $AZUL_DIR/azul >> $AZUL_PREFIX/bin/azul
 chmod 0755 $AZUL_PREFIX/bin/azul
-cp ./nvim/lua/azul.lua $AZUL_PREFIX/share/azul/nvim/lua
-cp ./nvim/init.lua $AZUL_PREFIX/share/azul/nvim
+cp $AZUL_DIR/nvim/lua/azul.lua $AZUL_PREFIX/share/azul/nvim/lua
+cp $AZUL_DIR/nvim/init.lua $AZUL_PREFIX/share/azul/nvim
 
 if [ ! -d $AZUL_CONFIG ]
 then
@@ -63,8 +68,8 @@ then
     git clone https://github.com/nvim-lua/plenary.nvim $AZUL_CONFIG/pack/start/plenary.nvim
     git clone https://github.com/nvim-telescope/telescope.nvim $AZUL_CONFIG/pack/start/telecope.nvim
 
-    cp ./examples/lua/* $AZUL_CONFIG/lua/
-    cp ./examples/azul.lua $AZUL_CONFIG/init.lua
+    cp $AZUL_DIR/examples/lua/* $AZUL_CONFIG/lua/
+    cp $AZUL_DIR/examples/azul.lua $AZUL_CONFIG/init.lua
 fi
 
 


### PR DESCRIPTION
Installation previously assumed that it always ran from the directory  where "azul" exists. This may not always be the case, so let's be  explicit and ensure that Azul's source directory is always referenced. This fixes the following errors in certain scenarios:

```bash
cat: ./azul: No such file or directory
cp: cannot stat './nvim/lua/azul.lua': No such file or directory
cp: cannot stat './nvim/init.lua': No such file or directory
```